### PR TITLE
feat: cursor support insert one

### DIFF
--- a/tests/pg/test_pg_sync.py
+++ b/tests/pg/test_pg_sync.py
@@ -54,6 +54,7 @@ def test_insert_one_returning(engine):
     assert_equals(db_data, [{"foo": 1, "bar": "baz"}])
     assert_equals(data, {"foo": 1, "bar": "baz"})
 
+
 @pytest.mark.usefixtures("setup_tables")
 def test_insert_one_cursor(engine):
     from tracktolib.pg_sync import insert_one, fetch_all
@@ -63,6 +64,7 @@ def test_insert_one_cursor(engine):
     engine.commit()
     db_data = fetch_all(engine, "SELECT foo, bar FROM foo.bar ORDER BY foo")
     assert_equals(db_data, [{"foo": 1, "bar": "baz"}])
+
 
 @pytest.mark.usefixtures("setup_tables")
 def test_insert_one_returning_cursor(engine):
@@ -74,6 +76,7 @@ def test_insert_one_returning_cursor(engine):
     db_data = fetch_all(engine, "SELECT foo, bar FROM foo.bar ORDER BY foo")
     assert_equals(db_data, [{"foo": 1, "bar": "baz"}])
     assert_equals(data, (1, "baz"))
+
 
 @pytest.mark.usefixtures("setup_tables", "insert_data")
 def test_fetch_count(engine):

--- a/tests/pg/test_pg_sync.py
+++ b/tests/pg/test_pg_sync.py
@@ -75,7 +75,7 @@ def test_insert_one_returning_cursor(engine):
     engine.commit()
     db_data = fetch_all(engine, "SELECT foo, bar FROM foo.bar ORDER BY foo")
     assert_equals(db_data, [{"foo": 1, "bar": "baz"}])
-    assert_equals(data, (1, "baz"))
+    assert_equals(data, {"foo": 1, "bar": "baz"})
 
 
 @pytest.mark.usefixtures("setup_tables", "insert_data")

--- a/tests/pg/test_pg_sync.py
+++ b/tests/pg/test_pg_sync.py
@@ -50,6 +50,7 @@ def test_insert_one_returning(engine):
     from tracktolib.pg_sync import insert_one, fetch_all
 
     data = insert_one(engine, "foo.bar", {"foo": 1, "bar": "baz"}, returning=["foo", "bar"])
+    assert data is not None
     db_data = fetch_all(engine, "SELECT foo, bar FROM foo.bar ORDER BY foo")
     assert_equals(db_data, [{"foo": 1, "bar": "baz"}])
     assert_equals(data, {"foo": 1, "bar": "baz"})
@@ -73,9 +74,10 @@ def test_insert_one_returning_cursor(engine):
     with engine.cursor() as cursor:
         data = insert_one(cursor, "foo.bar", {"foo": 1, "bar": "baz"}, returning=["foo", "bar"])
     engine.commit()
+    assert data is not None
     db_data = fetch_all(engine, "SELECT foo, bar FROM foo.bar ORDER BY foo")
     assert_equals(db_data, [{"foo": 1, "bar": "baz"}])
-    assert_equals(data, {"foo": 1, "bar": "baz"})
+    assert_equals(data, (1, "baz"))
 
 
 @pytest.mark.usefixtures("setup_tables", "insert_data")

--- a/tests/pg/test_pg_sync.py
+++ b/tests/pg/test_pg_sync.py
@@ -54,6 +54,26 @@ def test_insert_one_returning(engine):
     assert_equals(db_data, [{"foo": 1, "bar": "baz"}])
     assert_equals(data, {"foo": 1, "bar": "baz"})
 
+@pytest.mark.usefixtures("setup_tables")
+def test_insert_one_cursor(engine):
+    from tracktolib.pg_sync import insert_one, fetch_all
+
+    with engine.cursor() as cursor:
+        insert_one(cursor, "foo.bar", {"foo": 1, "bar": "baz"})
+    engine.commit()
+    db_data = fetch_all(engine, "SELECT foo, bar FROM foo.bar ORDER BY foo")
+    assert_equals(db_data, [{"foo": 1, "bar": "baz"}])
+
+@pytest.mark.usefixtures("setup_tables")
+def test_insert_one_returning_cursor(engine):
+    from tracktolib.pg_sync import insert_one, fetch_all
+
+    with engine.cursor() as cursor:
+        data = insert_one(cursor, "foo.bar", {"foo": 1, "bar": "baz"}, returning=["foo", "bar"])
+    engine.commit()
+    db_data = fetch_all(engine, "SELECT foo, bar FROM foo.bar ORDER BY foo")
+    assert_equals(db_data, [{"foo": 1, "bar": "baz"}])
+    assert_equals(data, {"foo": 1, "bar": "baz"})
 
 @pytest.mark.usefixtures("setup_tables", "insert_data")
 def test_fetch_count(engine):

--- a/tests/pg/test_pg_sync.py
+++ b/tests/pg/test_pg_sync.py
@@ -73,7 +73,7 @@ def test_insert_one_returning_cursor(engine):
     engine.commit()
     db_data = fetch_all(engine, "SELECT foo, bar FROM foo.bar ORDER BY foo")
     assert_equals(db_data, [{"foo": 1, "bar": "baz"}])
-    assert_equals(data, {"foo": 1, "bar": "baz"})
+    assert_equals(data, (1, "baz"))
 
 @pytest.mark.usefixtures("setup_tables", "insert_data")
 def test_fetch_count(engine):

--- a/tracktolib/pg_sync.py
+++ b/tracktolib/pg_sync.py
@@ -114,15 +114,19 @@ def insert_one(
     if returning:
         query = f"{query} RETURNING {','.join(returning)}"
         _is_returning = True
-
+    resp = None
     if isinstance(engine, Connection):
         with engine.cursor(row_factory=dict_row) as cur:
             _ = cur.execute(query, _data[0])
-            resp = cur.fetchone() if _is_returning else None
+            if _is_returning:
+                row = cur.fetchone()
+                resp = dict(row) if row is not None else None
         engine.commit()
     else:
         _ = engine.execute(query, _data[0])
-        resp = engine.fetchone() if _is_returning else None
+        if _is_returning:
+            row = engine.fetchone()
+            resp = dict(row) if row is not None else None
     return resp
 
 

--- a/tracktolib/pg_sync.py
+++ b/tracktolib/pg_sync.py
@@ -115,6 +115,7 @@ def insert_one(
         query = f"{query} RETURNING {','.join(returning)}"
         _is_returning = True
 
+    resp = None
     if isinstance(engine, Connection):
         with engine.cursor(row_factory=dict_row) as cur:
             _ = cur.execute(query, _data[0])
@@ -129,10 +130,6 @@ def insert_one(
                     raise RuntimeError("engine.description is None — cannot build dict from row.")
                 column_names = [col.name for col in engine.description]
                 resp = dict(zip(column_names, row))
-            else:
-                resp = None
-        else:
-            resp = None
 
     return resp
 

--- a/tracktolib/pg_sync.py
+++ b/tracktolib/pg_sync.py
@@ -105,15 +105,15 @@ def insert_one(
 
 @overload
 def insert_one(
-        engine: Cursor, table: LiteralString, data: Mapping[str, Any], returning: list[LiteralString]
+    engine: Cursor, table: LiteralString, data: Mapping[str, Any], returning: list[LiteralString]
 ) -> DictRow | TupleRow | None: ...
 
 
 def insert_one(
-        engine: Connection | Cursor,
-        table: LiteralString,
-        data: Mapping[str, Any],
-        returning: list[LiteralString] | None = None
+    engine: Connection | Cursor,
+    table: LiteralString,
+    data: Mapping[str, Any],
+    returning: list[LiteralString] | None = None,
 ) -> dict | DictRow | TupleRow | None:
     query, _data = get_insert_data(table, [data])
     _is_returning = False

--- a/tracktolib/pg_sync.py
+++ b/tracktolib/pg_sync.py
@@ -104,7 +104,10 @@ def insert_one(
 
 
 def insert_one(
-    engine: Connection | Cursor, table: LiteralString, data: Mapping[str, Any], returning: list[LiteralString] | None = None
+    engine: Connection | Cursor,
+    table: LiteralString,
+    data: Mapping[str, Any],
+    returning: list[LiteralString] | None = None,
 ) -> dict | None:
     query, _data = get_insert_data(table, [data])
     _is_returning = False

--- a/tracktolib/pg_sync.py
+++ b/tracktolib/pg_sync.py
@@ -7,7 +7,7 @@ try:
     from psycopg import Connection, Cursor
     from psycopg.abc import Query
     from psycopg.errors import InvalidCatalogName
-    from psycopg.rows import dict_row
+    from psycopg.rows import dict_row, DictRow, TupleRow
     from psycopg.types.json import Json
 except ImportError:
     raise ImportError('Please install psycopg or tracktolib with "pg-sync" to use this module')
@@ -103,19 +103,24 @@ def insert_one(
 ) -> dict: ...
 
 
+@overload
 def insert_one(
-    engine: Connection | Cursor,
-    table: LiteralString,
-    data: Mapping[str, Any],
-    returning: list[LiteralString] | None = None,
-) -> dict | None:
+        engine: Cursor, table: LiteralString, data: Mapping[str, Any], returning: list[LiteralString]
+) -> DictRow | TupleRow | None: ...
+
+
+def insert_one(
+        engine: Connection | Cursor,
+        table: LiteralString,
+        data: Mapping[str, Any],
+        returning: list[LiteralString] | None = None
+) -> dict | DictRow | TupleRow | None:
     query, _data = get_insert_data(table, [data])
     _is_returning = False
     if returning:
         query = f"{query} RETURNING {','.join(returning)}"
         _is_returning = True
 
-    resp = None
     if isinstance(engine, Connection):
         with engine.cursor(row_factory=dict_row) as cur:
             _ = cur.execute(query, _data[0])
@@ -123,14 +128,7 @@ def insert_one(
         engine.commit()
     else:
         _ = engine.execute(query, _data[0])
-        if _is_returning:
-            row = engine.fetchone()
-            if row is not None:
-                if engine.description is None:
-                    raise RuntimeError("engine.description is None — cannot build dict from row.")
-                column_names = [col.name for col in engine.description]
-                resp = dict(zip(column_names, row))
-
+        resp = engine.fetchone() if _is_returning else None
     return resp
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Insert operations now accept either a DB connection or an open cursor; connection-based inserts auto-commit, cursor-based inserts run in-place without auto-commit. Returning selected fields is supported in both modes and may yield driver-specific row objects when using a cursor.

* **Tests**
  * Added tests validating cursor-based inserts, returned fields, and behavior with and without auto-commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->