### PR TITLE
fix(s3): default to s3v4 signature when no config is provided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ tests/junit.xml
 .gemini/
 CLAUDE.md
 GEMINI.md
+AGENTS.md

--- a/tracktolib/s3/niquests.py
+++ b/tracktolib/s3/niquests.py
@@ -215,11 +215,14 @@ class S3Session:
             self._botocore_session = botocore.session.Session()
             if self.access_key is not None and self.secret_key is not None:
                 self._botocore_session.set_credentials(self.access_key, self.secret_key)
+            config = self.s3_config
+            if config is None:
+                config = Config(signature_version="s3v4")
             self.s3_client = self._botocore_session.create_client(
                 "s3",
                 endpoint_url=self.endpoint_url,
                 region_name=self.region,
-                config=self.s3_config,
+                config=config,
             )
 
     @property


### PR DESCRIPTION
- Default `s3_config` to `Config(signature_version="s3v4")` in `S3Session` when none is supplied
- Add `AGENTS.md` to `.gitignore`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced S3 client configuration to properly apply default settings when no custom configuration is specified.

* **Chores**
  * Updated build artifact ignore list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->