### PR TITLE
feat(pg): add SQLExpr for inlining raw SQL in insert/update values

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,39 @@ Async PostgreSQL helpers using [asyncpg](https://github.com/MagicStack/asyncpg).
 uv add tracktolib[pg]
 ```
 
+```python
+import asyncpg
+from tracktolib.pg import insert_one, insert_many, insert_returning, update_one, SQLExpr
+
+conn = await asyncpg.connect('postgresql://user:pass@localhost/db')
+
+# Insert a single row
+await insert_one(conn, 'public.test', {'foo': 'bar', 'value': 1})
+
+# Insert multiple rows
+await insert_many(conn, 'public.test', [
+    {'foo': 'bar', 'value': 1},
+    {'foo': 'baz', 'value': 2},
+])
+
+# Insert and return generated values
+new_id = await insert_returning(conn, 'public.test', {'foo': 'bar'}, returning='id')
+
+# Upsert (insert or update on conflict)
+from tracktolib.pg import Conflict
+await insert_one(conn, 'public.test', {'id': 1, 'foo': 'updated'}, on_conflict=Conflict(keys=['id']))
+
+# Update a single row
+await update_one(conn, 'public.test', {'foo': 'new', 'id': 1}, keys=['id'])
+
+# Use raw SQL expressions as values (e.g. NOW(), gen_random_uuid())
+await insert_one(conn, 'public.test', {'foo': 'bar', 'created_at': SQLExpr('NOW()')})
+# → INSERT INTO public.test AS t (created_at, foo) VALUES (NOW(), $1)
+
+await update_one(conn, 'public.test', {'updated_at': SQLExpr('NOW()'), 'id': 1}, keys=['id'])
+# → UPDATE public.test t SET updated_at = NOW() WHERE id = $1
+```
+
 ### pg-sync
 
 Sync PostgreSQL helpers using [psycopg](https://www.psycopg.org/psycopg3/) (v3).

--- a/tests/pg/test_pg.py
+++ b/tests/pg/test_pg.py
@@ -1,7 +1,9 @@
+import datetime as dt
+
 import asyncpg
 import pytest
 
-from tracktolib.pg import Conflict, PGConflictQuery
+from tracktolib.pg import Conflict, PGConflictQuery, SQLExpr
 from tracktolib.pg_sync import fetch_all, insert_one
 from tracktolib.tests import assert_equals
 
@@ -18,6 +20,62 @@ def test_insert_many_query():
 
     query = PGInsertQuery("schema.table", [{"foo": 1}, {"foo": 2}]).query
     assert query == "INSERT INTO schema.table AS t (foo) VALUES ($1)"
+
+
+@pytest.mark.parametrize(
+    "items,expected_query,expected_values",
+    [
+        pytest.param(
+            [{"foo": 1, "ts": SQLExpr("NOW()")}],
+            "INSERT INTO schema.table AS t (foo, ts) VALUES ($1, NOW())",
+            [(1,)],
+            id="insert_one_sql_expr",
+        ),
+        pytest.param(
+            [{"foo": 1, "ts": SQLExpr("NOW()")}, {"foo": 2, "ts": SQLExpr("NOW()")}],
+            "INSERT INTO schema.table AS t (foo, ts) VALUES ($1, NOW())",
+            [(1,), (2,)],
+            id="insert_many_sql_expr",
+        ),
+    ],
+)
+def test_insert_sql_expr_query(items, expected_query, expected_values):
+    from tracktolib.pg import PGInsertQuery
+
+    q = PGInsertQuery("schema.table", items)
+    assert q.query == expected_query
+    assert list(q.iter_values()) == expected_values
+
+
+@pytest.mark.parametrize(
+    "items,expected_query,expected_flat_values",
+    [
+        pytest.param(
+            [{"foo": 1, "ts": SQLExpr("NOW()")}, {"foo": 2, "ts": SQLExpr("NOW()")}],
+            "INSERT INTO schema.table AS t (foo, ts) VALUES ($1, NOW()), ($2, NOW()) RETURNING id",
+            [1, 2],
+            id="multi_row_returning_sql_expr",
+        ),
+    ],
+)
+def test_insert_many_returning_sql_expr_query(items, expected_query, expected_flat_values):
+    from tracktolib.pg import PGInsertQuery, PGReturningQuery
+
+    _returning = PGReturningQuery.load(keys=["id"])
+    q = PGInsertQuery("schema.table", items, returning=_returning)
+    assert q.query == expected_query
+    assert q._get_flat_values() == expected_flat_values
+
+
+def test_insert_many_inconsistent_sqlexpr_raises():
+    from tracktolib.pg import PGInsertQuery
+
+    items = [
+        {"foo": 1, "created": dt.datetime(2024, 1, 1), "ts": SQLExpr("NOW()")},
+        {"foo": 2, "created": dt.datetime(2024, 6, 1), "ts": dt.datetime(2024, 6, 1)},
+    ]
+    with pytest.raises(ValueError, match="Inconsistent SQLExpr"):
+        PGInsertQuery("schema.table", items).query
 
 
 @pytest.mark.parametrize(
@@ -461,6 +519,33 @@ async def test_fetch_count(aengine):
                 "values": [(10, 1, 100)],
             },
             id="one row - only first",
+        ),
+        pytest.param(
+            [{"foo": SQLExpr("NOW()"), "id": 1}],
+            {"where_keys": ["id"]},
+            {
+                "query": "UPDATE schema.table t SET foo = NOW() WHERE id = $1",
+                "values": [1],
+            },
+            id="sql_expr in set",
+        ),
+        pytest.param(
+            [{"foo": SQLExpr("NOW()"), "bar": 2, "id": 1}],
+            {"where_keys": ["id"]},
+            {
+                "query": "UPDATE schema.table t SET bar = $1, foo = NOW() WHERE id = $2",
+                "values": [2, 1],
+            },
+            id="sql_expr mixed with regular values",
+        ),
+        pytest.param(
+            [{"foo": SQLExpr("NOW()"), "id": 1}],
+            {"where_keys": ["id"], "returning": ["foo"]},
+            {
+                "query": "UPDATE schema.table t SET foo = NOW() WHERE id = $1 RETURNING foo",
+                "values": [1],
+            },
+            id="all set values are sql_expr",
         ),
     ],
 )

--- a/tracktolib/pg/__init__.py
+++ b/tracktolib/pg/__init__.py
@@ -5,6 +5,7 @@ from .query import (
     PGInsertQuery,
     PGReturningQuery,
     PGUpdateQuery,
+    SQLExpr,
     fetch_count,
     insert_many,
     insert_one,

--- a/tracktolib/pg/query.py
+++ b/tracktolib/pg/query.py
@@ -164,8 +164,16 @@ class PGInsertQuery(PGQuery):
     def _get_values_query(self) -> str:
         """Generate the VALUES clause for the query."""
         if len(self.items) == 1 or not self.is_returning:
-            if len(self.items) > 1:
-                first_expr = {k for k in self.keys if isinstance(self.items[0][k], SQLExpr)}
+            counter, parts, first_expr = 0, [], set()
+            for k in self.keys:
+                v = self.items[0][k]
+                if isinstance(v, SQLExpr):
+                    parts.append(v)
+                    first_expr.add(k)
+                else:
+                    counter += 1
+                    parts.append(f"${counter}")
+            if first_expr and len(self.items) > 1:
                 for item in self.items[1:]:
                     expr = {k for k in self.keys if isinstance(item[k], SQLExpr)}
                     if expr != first_expr:
@@ -173,14 +181,6 @@ class PGInsertQuery(PGQuery):
                             f"Inconsistent SQLExpr columns across rows for executemany: "
                             f"expected {first_expr}, got {expr}"
                         )
-            counter, parts = 0, []
-            for k in self.keys:
-                v = self.items[0][k]
-                if isinstance(v, SQLExpr):
-                    parts.append(v)
-                else:
-                    counter += 1
-                    parts.append(f"${counter}")
             return ", ".join(parts)
         else:
             # Multiple rows with returning: single VALUES list with flat params

--- a/tracktolib/pg/query.py
+++ b/tracktolib/pg/query.py
@@ -12,6 +12,10 @@ except ImportError:
 from tracktolib.utils import fill_dict
 
 
+class SQLExpr(str):
+    """Raw SQL expression inlined into the query instead of bound as a parameter."""
+
+
 def _get_insert_query[K: str](table: str, columns: Iterable[K], values: str) -> str:
     _columns = ", ".join(columns)
     return f"INSERT INTO {table} AS t ({_columns}) VALUES ({values})"
@@ -105,7 +109,7 @@ class PGQuery[K: str, V]:
     def iter_values(self, keys: list[K] | None = None) -> Iterator[tuple]:
         _keys = keys if keys is not None else self.keys
         for _item in self.items:
-            yield tuple(_item[k] for k in _keys)
+            yield tuple(v for k in _keys if not isinstance(v := _item[k], SQLExpr))
 
     @property
     def query(self) -> str:
@@ -159,19 +163,38 @@ class PGInsertQuery(PGQuery):
 
     def _get_values_query(self) -> str:
         """Generate the VALUES clause for the query."""
-        _columns = self.columns
-        num_cols = len(_columns)
-
         if len(self.items) == 1 or not self.is_returning:
-            # Single row or no returning: simple placeholders
-            return ", ".join(f"${i + 1}" for i in range(num_cols))
+            if len(self.items) > 1:
+                first_expr = {k for k in self.keys if isinstance(self.items[0][k], SQLExpr)}
+                for item in self.items[1:]:
+                    expr = {k for k in self.keys if isinstance(item[k], SQLExpr)}
+                    if expr != first_expr:
+                        raise ValueError(
+                            f"Inconsistent SQLExpr columns across rows for executemany: "
+                            f"expected {first_expr}, got {expr}"
+                        )
+            counter, parts = 0, []
+            for k in self.keys:
+                v = self.items[0][k]
+                if isinstance(v, SQLExpr):
+                    parts.append(v)
+                else:
+                    counter += 1
+                    parts.append(f"${counter}")
+            return ", ".join(parts)
         else:
-            # Multiple rows with returning: generate all value groups
-            value_groups = []
-            for row_idx in range(len(self.items)):
-                offset = row_idx * num_cols
-                group = ", ".join(f"${offset + i + 1}" for i in range(num_cols))
-                value_groups.append(f"({group})")
+            # Multiple rows with returning: single VALUES list with flat params
+            counter, value_groups = 0, []
+            for item in self.items:
+                group = []
+                for k in self.keys:
+                    v = item[k]
+                    if isinstance(v, SQLExpr):
+                        group.append(v)
+                    else:
+                        counter += 1
+                        group.append(f"${counter}")
+                value_groups.append(f"({', '.join(group)})")
             return ", ".join(value_groups)
 
     @property
@@ -231,15 +254,20 @@ def get_update_fields(
         if k in _ignore_keys:
             where_values.append(v)
             continue
-        values.append(v)
         _col = f'"{k}"' if quote_columns else k
-        _counter = counter + start_from + 1
-        fields.append(
-            f"{_col} = ${_counter}"
-            if k not in _merge_keys
-            else f"{_col} = COALESCE(t.{_col}, JSONB_BUILD_OBJECT()) || ${_counter}"
-        )
-        counter += 1
+        if isinstance(v, SQLExpr):
+            fields.append(
+                f"{_col} = {v}" if k not in _merge_keys else f"{_col} = COALESCE(t.{_col}, JSONB_BUILD_OBJECT()) || {v}"
+            )
+        else:
+            values.append(v)
+            _counter = counter + start_from + 1
+            fields.append(
+                f"{_col} = ${_counter}"
+                if k not in _merge_keys
+                else f"{_col} = COALESCE(t.{_col}, JSONB_BUILD_OBJECT()) || ${_counter}"
+            )
+            counter += 1
     return ",\n".join(fields), values + where_values
 
 
@@ -288,7 +316,7 @@ class PGUpdateQuery(PGQuery):
 
     @property
     def values(self):
-        if not self._values:
+        if self._values is None:
             raise ValueError("No values found")
         if len(self.items) == 1 and not self.is_many:
             return self._values
@@ -301,8 +329,13 @@ class PGUpdateQuery(PGQuery):
         if self.where:
             return self.where
         elif self.where_keys is not None:
-            start_from = self.start_from if self.start_from is not None else len(self.keys) - len(self.where_keys)
-
+            if self.start_from is not None:
+                start_from = self.start_from
+            else:
+                _where_set = set(self.where_keys)
+                start_from = sum(
+                    1 for k in self.keys if k not in _where_set and not isinstance(self.items[0][k], SQLExpr)
+                )
             return "WHERE " + " AND ".join(f"{k} = ${i + start_from + 1}" for i, k in enumerate(self.where_keys))
         return ""
 

--- a/uv.lock
+++ b/uv.lock
@@ -1896,7 +1896,7 @@ wheels = [
 
 [[package]]
 name = "tracktolib"
-version = "0.73.0"
+version = "0.74.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Introduces SQLExpr(str) subclass so callers can pass raw SQL expressions (NOW(), CURRENT_TIMESTAMP, gen_random_uuid(), etc.) as column values instead of bound parameters. Validates consistency across executemany rows and fixes WHERE clause $n offset when SET columns are SQLExpr.