### PR TITLE
ci: use the org-wide SOREN_PAT (replaces SRE_TOKEN)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
-          token: ${{ secrets.SRE_TOKEN }}
+          token: ${{ secrets.SOREN_PAT }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2


### PR DESCRIPTION
Part of consolidating release tokens on the org-wide `SOREN_PAT` (removing `SRE_TOKEN`). NB: requires the SOREN_PAT token's repository access to include this repo.